### PR TITLE
fix: import proper typings to http-error

### DIFF
--- a/src/http-error.ts
+++ b/src/http-error.ts
@@ -1,3 +1,4 @@
+import { Response } from '../typings/syncano-context'
 export class HttpError extends Error {
   public statusCode: number
   public response?: Response & {


### PR DESCRIPTION
Current implementation throws errors under the newest typescript transpiler:
![screen shot 2018-12-13 at 03 05 23](https://user-images.githubusercontent.com/347657/49910727-14a07b80-fe84-11e8-8c7c-615de0b7aedd.png)
